### PR TITLE
add signature check

### DIFF
--- a/tests/test_func.py
+++ b/tests/test_func.py
@@ -1,0 +1,30 @@
+import pytest
+
+import znflow
+
+
+@znflow.nodify
+def add(a, b):
+    return a + b
+
+
+def test_add():
+    assert add(1, 2) == 3
+    with znflow.DiGraph() as graph:
+        out = add(1, 2)
+
+    graph.run()
+    assert out.result == 3
+
+
+@pytest.mark.parametrize(
+    ("args", "kwargs"),
+    [(tuple(), dict()), ((5,), dict()), (tuple(), {"a": 5}), ((5, 6), {"a": 7})],
+)
+def test_add_args(args, kwargs):
+    with pytest.raises(TypeError):
+        add(*args, **kwargs)
+
+    with pytest.raises(TypeError):
+        with znflow.DiGraph():
+            add(*args, **kwargs)

--- a/tests/test_node.py
+++ b/tests/test_node.py
@@ -50,6 +50,14 @@ def compute_sum(*args):
 
 
 @pytest.mark.parametrize("cls", [PlainNode, DataclassNode, ZnInitNode, add, AttrsNode])
+def test_Node_init(cls):
+    with pytest.raises((TypeError, AttributeError)):
+        # TODO only raise TypeError and not AttributeError when TypeError is expected.
+        with znflow.DiGraph():
+            cls()
+
+
+@pytest.mark.parametrize("cls", [PlainNode, DataclassNode, ZnInitNode, add, AttrsNode])
 def test_Node(cls):
     with znflow.DiGraph() as graph:
         node = cls(value=42)
@@ -162,8 +170,8 @@ def test_ConnectionNodifyMultiNode(cls1, cls2):
 @pytest.mark.parametrize("cls2", [PlainNode, DataclassNode, ZnInitNode, AttrsNode])
 def test_ConnectionNodeMultiNodify(cls1, cls2):
     with znflow.DiGraph() as graph:
-        node1 = cls1(value=42)
-        node2 = cls1(value=42)
+        node1 = cls1(42)
+        node2 = cls1(42)
         node3 = cls2(value=[node1, node2])
 
     assert node1.uuid in graph

--- a/znflow/node.py
+++ b/znflow/node.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import functools
+import inspect
 import uuid
 
 from znflow.base import Connection, FunctionFuture, NodeBaseMixin, get_graph
@@ -77,9 +78,18 @@ def nodify(function):
 
     @functools.wraps(function)
     def wrapper(*args, **kwargs):
-        """Wrapper function for the decorator."""
+        """Wrapper function for the decorator.
+
+        Raises
+        ------
+        TypeError:
+            if the args / kwargs do not match the function signature
+        """
         graph = get_graph()
         if graph is not None:
+            # check if the args / kwargs match the function
+            inspect.signature(function).bind(*args, **kwargs)
+
             future = FunctionFuture(function, args, kwargs)
             future.uuid = uuid.uuid4()
 


### PR DESCRIPTION
It was possible to do run the following without TypeError. The TypeError only occured after `graph.run()`
This is now fixed.

```python
import znflow

@znflow.nodify
def add(a, b):
    return a + b

with znflow.DiGraph():
      add()
```