### PR TITLE
add getitem support for attributes and FunctionFuture

### DIFF
--- a/tests/test_getitem.py
+++ b/tests/test_getitem.py
@@ -1,7 +1,5 @@
 import dataclasses
 
-import pytest
-
 import znflow
 
 
@@ -58,7 +56,7 @@ def test_GetList():
 
     assert isinstance(y, znflow.Connection)
 
-    assert y.instance is x
+    assert y.instance.instance is x  # y.instance == Connection(instance=x, ...)
     assert len(graph) == 1
 
     assert x.data == list(range(10))
@@ -89,8 +87,16 @@ def test_getitem_with_sum():
 
 
 def test_multi_getitem():
-    with znflow.DiGraph():
+    with znflow.DiGraph() as graph:
         node_a = get_list()
         x = node_a[::2]
-        with pytest.raises(TypeError):
-            _ = x[::2]
+        y = x[::2]
+
+        out = add_lists(x, y)
+
+    graph.run()
+    assert len(graph) == 2  # node_a and out
+    assert node_a.result == list(range(10))
+    assert x.result == list(range(0, 10, 2))
+    assert y.result == list(range(0, 10, 4))
+    assert out.result == list(range(0, 10, 2)) + list(range(0, 10, 4))

--- a/tests/test_getitem.py
+++ b/tests/test_getitem.py
@@ -1,5 +1,7 @@
 import dataclasses
 
+import pytest
+
 import znflow
 
 
@@ -84,3 +86,11 @@ def test_getitem_with_sum():
     assert node_a.result == list(range(10))
     assert node_b.data == list(range(10))
     assert node_c.result == list(range(10))
+
+
+def test_multi_getitem():
+    with znflow.DiGraph():
+        node_a = get_list()
+        x = node_a[::2]
+        with pytest.raises(TypeError):
+            _ = x[::2]

--- a/tests/test_getitem.py
+++ b/tests/test_getitem.py
@@ -1,0 +1,86 @@
+import dataclasses
+
+import znflow
+
+
+@znflow.nodify
+def get_list() -> list:
+    return list(range(10))
+
+
+@znflow.nodify
+def add_lists(a, b):
+    return a + b
+
+
+@dataclasses.dataclass
+class GetList(znflow.Node):
+    maximum: int
+    data: list = None
+
+    def run(self):
+        self.data = list(range(self.maximum))
+
+
+def test_get_list():
+    assert get_list() == list(range(10))
+    assert get_list()[::2] == list(range(0, 10, 2))
+
+    with znflow.DiGraph() as graph:
+        x = get_list()
+        y = x[::2]
+
+    graph.run()
+
+    assert isinstance(x, znflow.FunctionFuture)
+    assert isinstance(y, znflow.Connection)
+
+    assert y.instance is x
+    assert len(graph) == 1
+
+    assert x.result == list(range(10))
+    assert y.result == list(range(0, 10, 2))
+
+
+def test_GetList():
+    instance = GetList(10)
+    instance.run()
+    assert instance.data == list(range(10))
+    assert instance.data[::2] == list(range(0, 10, 2))
+
+    with znflow.DiGraph() as graph:
+        x = GetList(10)
+        y = x.data[::2]
+
+    graph.run()
+
+    assert isinstance(y, znflow.Connection)
+
+    assert y.instance is x
+    assert len(graph) == 1
+
+    assert x.data == list(range(10))
+    assert y.result == list(range(0, 10, 2))
+
+
+def test_getitem_with_sum():
+    a = get_list()
+    b = GetList(10)
+    b.run()
+
+    c = add_lists(a[:5], b.data[5:])
+
+    assert a == list(range(10))
+    assert b.data == list(range(10))
+    assert c == list(range(10))
+
+    with znflow.DiGraph() as graph:
+        node_a = get_list()
+        node_b = GetList(10)
+
+        node_c = add_lists(node_a[:5], node_b.data[5:])
+
+    graph.run()
+    assert node_a.result == list(range(10))
+    assert node_b.data == list(range(10))
+    assert node_c.result == list(range(10))

--- a/znflow/base.py
+++ b/znflow/base.py
@@ -89,7 +89,7 @@ class Connection:
     item: any = None
 
     def __getitem__(self, item):
-        return type(self)(instance=self, attribute="result", item=item)
+        return dataclasses.replace(self, instance=self, attribute="result", item=item)
 
     @property
     def uuid(self):
@@ -101,9 +101,7 @@ class Connection:
             getattr(self.instance, self.attribute) if self.attribute else self.instance
         )
 
-        if self.item is None:
-            return result
-        return result[self.item]
+        return result[self.item] if self.item else result
 
 
 @dataclasses.dataclass

--- a/znflow/base.py
+++ b/znflow/base.py
@@ -86,6 +86,10 @@ class Connection:
 
     instance: any
     attribute: any
+    item: any = None
+
+    def __getitem__(self, item):
+        return dataclasses.replace(self, item=item)
 
     @property
     def uuid(self):
@@ -93,9 +97,13 @@ class Connection:
 
     @property
     def result(self):
-        if self.attribute is None:
-            return self.instance
-        return getattr(self.instance, self.attribute)
+        result = (
+            getattr(self.instance, self.attribute) if self.attribute else self.instance
+        )
+
+        if self.item is None:
+            return result
+        return result[self.item]
 
 
 @dataclasses.dataclass
@@ -103,6 +111,7 @@ class FunctionFuture(NodeBaseMixin):
     function: typing.Callable
     args: typing.Tuple
     kwargs: typing.Dict
+    item: any = None
 
     _result: any = dataclasses.field(default=None, init=False, repr=True)
 
@@ -111,9 +120,11 @@ class FunctionFuture(NodeBaseMixin):
     def run(self):
         self._result = self.function(*self.args, **self.kwargs)
 
+    def __getitem__(self, item):
+        return Connection(instance=self, attribute="result", item=item)
+
     @property
     def result(self):
         if self._result is None:
             self.run()
-
         return self._result

--- a/znflow/base.py
+++ b/znflow/base.py
@@ -89,6 +89,11 @@ class Connection:
     item: any = None
 
     def __getitem__(self, item):
+        if self.item is not None:
+            raise TypeError(
+                f"'__getitem__' call to {self} where 'item is not None' is currently not"
+                " supported."
+            )
         return dataclasses.replace(self, item=item)
 
     @property

--- a/znflow/base.py
+++ b/znflow/base.py
@@ -89,12 +89,7 @@ class Connection:
     item: any = None
 
     def __getitem__(self, item):
-        if self.item is not None:
-            raise TypeError(
-                f"'__getitem__' call to {self} where 'item is not None' is currently not"
-                " supported."
-            )
-        return dataclasses.replace(self, item=item)
+        return type(self)(instance=self, attribute="result", item=item)
 
     @property
     def uuid(self):


### PR DESCRIPTION
Support
```python
import znflow

@znflow.nodify
def func() -> list: ...

class Compute(znflow.Node):
   data = [1, 2, 3]

with znflow.DiGraph() as graph:
   func()[::2]
   Compute().data[::2]
```

it does **not** support

```python
import znflow

class Compute(znflow.Node):
   def __getitem__(self, item): ...

with znflow.DiGraph() as graph:
   Compute()[::2]
```
