### PR TITLE
add disable argument to DiGraph

### DIFF
--- a/tests/test_digraph.py
+++ b/tests/test_digraph.py
@@ -23,9 +23,20 @@ class ComputeSum(znflow.Node):
 def test_combine_nodes():
     with znflow.DiGraph() as graph:
         n1 = ComputeSum(inputs=(1, 2, 3))
-        n2 = ComputeSum(inputs=(4, 5, 6))
-        n3 = ComputeSum(inputs=(n1.outputs, n2.outputs))
+        n2 = add(4, 5, 6)
+        n3 = ComputeSum(inputs=(n1.outputs, n2))
 
     graph.run()
+
+    assert n3.outputs == 21
+
+
+def test_combine_nodes_disable():
+    with znflow.DiGraph(disable=True):
+        n1 = ComputeSum(inputs=(1, 2, 3))
+        n2 = add(4, 5, 6)
+        n1.run()  # when the graph is disabled, we must call run.
+        n3 = ComputeSum(inputs=(n1.outputs, n2))
+        n3.run()
 
     assert n3.outputs == 21

--- a/znflow/graph.py
+++ b/znflow/graph.py
@@ -47,13 +47,21 @@ class _UpdateConnectors(utils.IterableHandler):
 
 
 class DiGraph(nx.MultiDiGraph):
+    def __init__(self, *args, disable=False, **kwargs):
+        self.disable = disable
+        super().__init__(*args, **kwargs)
+
     def __enter__(self):
+        if self.disable:
+            return self
         if get_graph() is not None:
             raise ValueError("DiGraph already exists. Nested Graphs are not supported.")
         set_graph(self)
         return self
 
     def __exit__(self, exc_type, exc_val, exc_tb):
+        if self.disable:
+            return
         if get_graph() is not self:
             raise ValueError(
                 "Something went wrong. DiGraph was changed inside the context manager."


### PR DESCRIPTION
A disabled graph won't have an affect of the contents within it.
Be aware, that this means, run methods might have to be called inside the context manager.
```
with znflow.DiGraph(disable=True):
   ...
```