### PR TITLE
Fix properties

### DIFF
--- a/tests/test_get_attribute.py
+++ b/tests/test_get_attribute.py
@@ -37,7 +37,7 @@ class POW2(znflow.Node):
 def test_get_attribute():
     with znflow.DiGraph() as graph:
         n1 = POW2()
-        n1.x = 4.0
+        n1.x = 4.0  # converted to 2.0
 
     graph.run()
     assert n1.x == 2.0

--- a/tests/test_node.py
+++ b/tests/test_node.py
@@ -15,6 +15,10 @@ class PlainNode(znflow.Node):
     def run(self):
         self.value += 1
 
+    @property
+    def output(self):
+        return znflow.get_attribute(self, "value")
+
 
 @dataclasses.dataclass
 class DataclassNode(znflow.Node):
@@ -23,12 +27,20 @@ class DataclassNode(znflow.Node):
     def run(self):
         self.value += 1
 
+    @property
+    def output(self):
+        return znflow.get_attribute(self, "value")
+
 
 class ZnInitNode(zninit.ZnInit, znflow.Node):
     value: int = zninit.Descriptor()
 
     def run(self):
         self.value += 1
+
+    @property
+    def output(self):
+        return znflow.get_attribute(self, "value")
 
 
 @attrs.define
@@ -37,6 +49,10 @@ class AttrsNode(znflow.Node):
 
     def run(self):
         self.value += 1
+
+    @property
+    def output(self):
+        return znflow.get_attribute(self, "value")
 
 
 @znflow.nodify

--- a/znflow/base.py
+++ b/znflow/base.py
@@ -87,6 +87,10 @@ class Connection:
     instance: any
     attribute: any
 
+    def __post_init__(self):
+        if self.attribute is not None and self.attribute.startswith("_"):
+            raise ValueError("Private attributes are not allowed.")
+
     @property
     def uuid(self):
         return self.instance.uuid

--- a/znflow/graph.py
+++ b/znflow/graph.py
@@ -1,4 +1,6 @@
+import functools
 import logging
+import typing
 
 import networkx as nx
 
@@ -11,42 +13,41 @@ log = logging.getLogger(__name__)
 
 class _AttributeToConnection(utils.IterableHandler):
     def default(self, value, **kwargs):
-        v_attr = kwargs.get("v_attr")
-        node_instance = kwargs["node_instance"]
-        graph = kwargs["graph"]
-
+        assert not kwargs
         if isinstance(value, FunctionFuture):
-            connection = Connection(value, attribute="result")
-            if v_attr is None:
-                graph.add_connections(connection, node_instance)
-            else:
-                graph.add_connections(connection, node_instance, v_attr=v_attr)
-
-            return connection
+            return Connection(value, attribute="result")
         elif isinstance(value, Node):
-            connection = Connection(value, attribute=None)
-            if v_attr is None:
-                graph.add_connections(connection, node_instance)
-            else:
-                graph.add_connections(connection, node_instance, v_attr=v_attr)
-            return connection
-        elif isinstance(value, Connection):
+            return Connection(value, attribute=None)
+        else:
+            return value
+
+
+class _AddConnectionToGraph(utils.IterableHandler):
+    def default(self, value, **kwargs):
+        if isinstance(value, Connection):
+            graph = kwargs["graph"]
+            v_attr = kwargs.get("attribute")
+            node_instance = kwargs["node_instance"]
             if v_attr is None:
                 graph.add_connections(value, node_instance)
             else:
                 graph.add_connections(value, node_instance, v_attr=v_attr)
-            return value
-        return value
 
 
 class _UpdateConnectors(utils.IterableHandler):
     def default(self, value, **kwargs):
-        if isinstance(value, Connection):
-            return value.result
-        return value
+        return value.result if isinstance(value, Connection) else value
 
 
 class DiGraph(nx.MultiDiGraph):
+    @property
+    def add_connections_from_iterable(self) -> typing.Callable:
+        """Get a function that adds connections to the graph.
+
+        Return a _AddConnectionToGraph class with this Graph instance attached.
+        """
+        return functools.partial(_AddConnectionToGraph(), graph=self)
+
     def __enter__(self):
         if get_graph() is not None:
             raise ValueError("DiGraph already exists. Nested Graphs are not supported.")
@@ -63,28 +64,37 @@ class DiGraph(nx.MultiDiGraph):
             node_instance = self.nodes[node]["value"]
             log.debug(f"Node {node} ({node_instance}) was added to the graph.")
             if isinstance(node_instance, FunctionFuture):
-                node_instance.args = _AttributeToConnection()(
-                    node_instance.args, node_instance=node_instance, graph=self
-                )
-                node_instance.kwargs = _AttributeToConnection()(
-                    node_instance.kwargs, node_instance=node_instance, graph=self
-                )
+                self._update_function_future_arguments(node_instance)
             elif isinstance(node_instance, Node):
                 self._update_node_attributes(node_instance, _AttributeToConnection())
 
-    def _update_node_attributes(self, node_instance, updater):
+    def _update_function_future_arguments(self, node_instance: FunctionFuture) -> None:
+        """Apply an update to args and kwargs of a FunctionFuture."""
+        node_instance.args = _AttributeToConnection()(node_instance.args)
+        node_instance.kwargs = _AttributeToConnection()(node_instance.kwargs)
+        self.add_connections_from_iterable(
+            node_instance.args, node_instance=node_instance
+        )
+        self.add_connections_from_iterable(
+            node_instance.kwargs, node_instance=node_instance
+        )
+
+    def _update_node_attributes(self, node_instance: Node, updater) -> None:
         """Apply an updater to all attributes of a node."""
         for attribute in dir(node_instance):
             if attribute.startswith("_") or attribute in Node._protected_:
+                # We do not allow connections to private attributes.
                 continue
-            value = updater(
-                getattr(node_instance, attribute),
-                node_instance=node_instance,
-                graph=self,
-                v_attr=attribute,
-            )
+            value = getattr(node_instance, attribute)
+            value = updater(value)
             if updater.updated:
-                setattr(node_instance, attribute, value)
+                try:
+                    setattr(node_instance, attribute, value)
+                except AttributeError:
+                    continue
+            self.add_connections_from_iterable(
+                value, node_instance=node_instance, attribute=attribute
+            )
 
     def add_node(self, node_for_adding, **attr):
         if isinstance(node_for_adding, NodeBaseMixin):

--- a/znflow/node.py
+++ b/znflow/node.py
@@ -60,6 +60,7 @@ class Node(NodeBaseMixin):
         return value
 
     def __setattr__(self, item, value) -> None:
+        super().__setattr__(item, value)
         if get_graph() is not None:
             if isinstance(value, Connection):
                 assert (
@@ -69,7 +70,6 @@ class Node(NodeBaseMixin):
                 self._graph_.add_edge(
                     value.uuid, self.uuid, u_attr=value.attribute, v_attr=item
                 )
-        super().__setattr__(item, value)
 
 
 def nodify(function):


### PR DESCRIPTION
There was an issue if you have a Node like:

```python
class PlainNode(znflow.Node):
    def __init__(self, value):
        self.value = value

    def run(self):
        self.value += 1

    @property
    def output(self):
        return znflow.get_attribute(self, "value")
```

Here `PlainNode().output` could return a `Connection`.
If the `_AttributeToConnection` would try to update `output` before `value` it tries to set `PlainNode().output = Connection.result` which is not allowed.

This is now fixed.