### PR TITLE
Allow non graph

### DIFF
--- a/znflow/graph.py
+++ b/znflow/graph.py
@@ -121,6 +121,9 @@ class DiGraph(nx.MultiDiGraph):
         if isinstance(u_of_edge, Connection) and isinstance(v_of_edge, NodeBaseMixin):
             assert u_of_edge.uuid in self, f"'{u_of_edge.uuid=}' not in '{self=}'"
             assert v_of_edge.uuid in self, f"'{v_of_edge.uuid=}' not in '{self=}'"
+            # TODO what if 'v_attr' is a list/dict/... that contains multiple connections?
+            #  Is this relevant? We could do `v_attr.<dict_key>` or `v_attr.<list_index>`
+            #  See test_node.test_ListConnection and test_node.test_DictionaryConnection
             self.add_edge(
                 u_of_edge.uuid,
                 v_of_edge.uuid,

--- a/znflow/node.py
+++ b/znflow/node.py
@@ -57,7 +57,9 @@ class Node(NodeBaseMixin):
         return instance
 
     def __getattribute__(self, item):
-        if get_graph() is not None:
+        if item == "_graph_":
+            return super().__getattribute__(item)
+        if self._graph_ is not None:
             with disable_graph():
                 if item not in set(dir(self)):
                     raise AttributeError(
@@ -73,7 +75,7 @@ class Node(NodeBaseMixin):
 
     def __setattr__(self, item, value) -> None:
         super().__setattr__(item, value)
-        if get_graph() is not None:
+        if self._graph_ is not None:
             if isinstance(value, Connection):
                 assert (
                     self.uuid in self._graph_


### PR DESCRIPTION
Add a method to "not add" a Node to a graph.
Basically:

```python
node1 = DataclassNode(value=42)
    node1._graph_ = None
    assert node1.value == 42

    with znflow.DiGraph() as graph:
        node2 = DataclassNode(value=18)
        node3 = compute_sum(node1.value, node2.value)
```

here `node1` is not part of the graph and interpreted as values directly. The `run` method will not be called.