### PR TITLE
allow sum

### DIFF
--- a/tests/test_add_connections.py
+++ b/tests/test_add_connections.py
@@ -116,7 +116,6 @@ def test_sum_list():
         outs1 = sum(data1)
         outs2 = sum(data2)
         outs = sum([outs1, outs2])
-        
 
     graph.run()
 

--- a/tests/test_add_connections.py
+++ b/tests/test_add_connections.py
@@ -110,8 +110,8 @@ def test_add_node_nodify_nested():
 
 def test_sum_list():
     with znflow.DiGraph() as graph:
-        data1 = [create_list(5) for _ in range(5)]
-        data2 = [CreateList(5).outs for _ in range(5)]
+        data1 = [create_list(x) for x in range(5)]
+        data2 = [CreateList(x).outs for x in range(5)]
 
         outs1 = sum(data1)
         outs2 = sum(data2)
@@ -119,7 +119,11 @@ def test_sum_list():
 
     graph.run()
 
-    assert outs.result == list(range(5)) * 10
+    result = []
+    for x in [list(range(x)) for x in range(5)]:
+        result.extend(x)
+    result = result + result
+    assert outs.result == result
 
 
 # test errors

--- a/tests/test_add_connections.py
+++ b/tests/test_add_connections.py
@@ -108,6 +108,21 @@ def test_add_node_nodify_nested():
     assert outs.result == list(range(1, 6)) * 11
 
 
+def test_sum_list():
+    with znflow.DiGraph() as graph:
+        data1 = [create_list(5) for _ in range(5)]
+        data2 = [CreateList(5).outs for _ in range(5)]
+
+        outs1 = sum(data1)
+        outs2 = sum(data2)
+        outs = sum([outs1, outs2])
+        
+
+    graph.run()
+
+    assert outs.result == list(range(5)) * 10
+
+
 # test errors
 
 

--- a/tests/test_add_connections.py
+++ b/tests/test_add_connections.py
@@ -122,8 +122,26 @@ def test_sum_list():
     result = []
     for x in [list(range(x)) for x in range(5)]:
         result.extend(x)
-    result = result + result
-    assert outs.result == result
+    assert outs.result == result + result
+
+
+def test_combine():
+    with znflow.DiGraph() as graph:
+        data1 = [create_list(x) for x in range(5)]
+        data2 = [CreateList(x) for x in range(5)]
+
+        outs1 = znflow.combine(data1)
+        outs2 = znflow.combine(*data1)
+        outs3 = znflow.combine(data2, attribute="outs")
+        outs4 = znflow.combine(*data2, attribute="outs")
+        outs = sum([outs1, outs2, outs3, outs4])
+
+    graph.run()
+
+    result = []
+    for x in [list(range(x)) for x in range(5)]:
+        result.extend(x)
+    assert outs.result == result + result + result + result
 
 
 # test errors

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -56,9 +56,6 @@ def test_run_graph():
     assert node1.value == 42
     assert node2.value == 18
 
-    with pytest.raises(TypeError):
-        node3.run()
-
     graph.run()
 
     assert node1.value == 43

--- a/znflow/__init__.py
+++ b/znflow/__init__.py
@@ -13,6 +13,7 @@ from znflow.base import (
 )
 from znflow.graph import DiGraph
 from znflow.node import Node, nodify
+from znflow.utils import combine
 from znflow.visualize import draw
 
 __version__ = importlib.metadata.version(__name__)
@@ -28,6 +29,7 @@ __all__ = [
     "disable_graph",
     "Property",
     "CombinedConnections",
+    "combine",
 ]
 
 logger = logging.getLogger(__name__)

--- a/znflow/base.py
+++ b/znflow/base.py
@@ -160,6 +160,11 @@ class Connection:
             return CombinedConnections(connections=[self, other])
         raise TypeError(f"Can not add {type(other)} to {type(self)}.")
 
+    def __radd__(self, other):
+        if other == 0:  # python uses sum(..., start=0) so we need to handle this case
+            return self
+        return self.__add__(other)
+
     @property
     def uuid(self):
         return self.instance.uuid
@@ -230,6 +235,11 @@ class CombinedConnections:
         else:
             raise TypeError(f"Can not add {type(other)} to {type(self)}.")
 
+    def __radd__(self, other):
+        if other == 0:  # python uses sum(..., start=0) so we need to handle this case
+            return self
+        return self.__add__(other)
+
     def __getitem__(self, item):
         return dataclasses.replace(self, item=item)
 
@@ -276,3 +286,8 @@ class FunctionFuture(NodeBaseMixin):
         if isinstance(other, (Connection, FunctionFuture, CombinedConnections)):
             return CombinedConnections(connections=[self, other])
         raise TypeError(f"Can not add {type(other)} to {type(self)}.")
+
+    def __radd__(self, other):
+        if other == 0:  # python uses sum(..., start=0) so we need to handle this case
+            return self
+        return self.__add__(other)

--- a/znflow/utils.py
+++ b/znflow/utils.py
@@ -61,3 +61,32 @@ class IterableHandler(abc.ABC):
     def _(self, value: dict, **kwargs) -> dict:
         """Handle a dict."""
         return {key: self.handle(val, **kwargs) for key, val in value.items()}
+
+
+def combine(*args, attribute=None):
+    """Combine Node outputs which are lists into a single flat list.
+
+    Attributes
+    ----------
+    args : list of Node instances
+    attribute : str, default=None
+        If not None, the attribute of the Node instance is gathered.
+
+    Examples
+    --------
+    The following are all allowed:
+    >>> combine([a, b, c])
+    >>> combine(a, b, c)
+    >>> combine([a, b, c], attribute="outs")
+    >>> combine(a, b, c, attribute="outs")
+
+    Returns
+    -------
+    CombinedConnections:
+        A combined connections object.
+    """
+    if len(args) == 1 and isinstance(args[0], (list, tuple)):
+        args = args[0]
+    if attribute is None:
+        return sum(args)
+    return sum(map(lambda x: getattr(x, attribute), args))


### PR DESCRIPTION
Basically allow:

```python
def test_sum_list():
    with znflow.DiGraph() as graph:
        data1 = [create_list(5) for _ in range(5)]
        data2 = [CreateList(5).outs for _ in range(5)]

        outs1 = sum(data1)
        outs2 = sum(data2)
        outs = sum([outs1, outs2])
```

instead of:

```python
def test_sum_list():
    with znflow.DiGraph() as graph:
        outs1 = create_list(5)
        for _ in range(4):
             outs1 += create_list(5)

        outs2 = CreateList(5).outs
        for _ in range(4):
             outs2 += CreateList(5).outs

        outs1 = sum(data1)
        outs2 = sum(data2)
        outs = outs1[0]
        for x in outs1[1:]:
            outs += x
       for x in outs2:
           outs += x
```

There shouldn't be an issue with other `sum` behaviour because:

```python
>>> sum([[1, 2], [3, 4]])
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
TypeError: unsupported operand type(s) for +: 'int' and 'list'
```