### PR TITLE
allow dynamic resolving within the graph

### DIFF
--- a/tests/test_dynamic.py
+++ b/tests/test_dynamic.py
@@ -5,8 +5,8 @@ import znflow
 
 @dataclasses.dataclass
 class AddOne(znflow.Node):
-    inputs: float
-    outputs: float = None
+    inputs: int
+    outputs: int = None
 
     def run(self):
         # if self.outputs is not None:
@@ -88,3 +88,12 @@ def test_resolvce_only_run_relevant_nodes():
     graph.run()
     assert node2.outputs == 1235
     assert node1.outputs == 6
+
+def test_connections_remain():
+    graph = znflow.DiGraph()
+    with graph:
+        node1 = AddOne(inputs=1)
+        result = znflow.resolve(node1.outputs)
+        assert isinstance(result, int)
+        assert isinstance(node1.outputs, znflow.Connection)
+            

--- a/tests/test_dynamic.py
+++ b/tests/test_dynamic.py
@@ -97,3 +97,16 @@ def test_connections_remain():
         result = znflow.resolve(node1.outputs)
         assert isinstance(result, int)
         assert isinstance(node1.outputs, znflow.Connection)
+
+
+def test_loop_over_results():
+    graph = znflow.DiGraph()
+    with graph:
+        node1 = AddOne(inputs=5)
+        nodes = []
+        for idx in range(znflow.resolve(node1.outputs)):
+            nodes.append(AddOne(inputs=idx))
+        
+    graph.run()
+    assert len(nodes) == 6
+    assert [node.outputs for node in nodes] == [1, 2, 3, 4, 5, 6]

--- a/tests/test_dynamic.py
+++ b/tests/test_dynamic.py
@@ -10,7 +10,9 @@ class AddOne(znflow.Node):
     def run(self):
         self.outputs = self.inputs + 1
 
+
 def test_break_loop():
+    """Test loop breaking when output exceeds 5."""
     graph = znflow.DiGraph()
     with graph:
         node1 = AddOne(inputs=1)
@@ -20,5 +22,37 @@ def test_break_loop():
                 break
 
     graph.run()
+
+    # Assert the correct number of nodes in the graph
     assert len(graph) == 5
+
+    # Assert the final output value
     assert node1.outputs == 6
+
+
+def test_break_loop_multiple():
+    """Test loop breaking with multiple nodes and different conditions."""
+    graph = znflow.DiGraph()
+    with graph:
+        node1 = AddOne(inputs=1)
+        node2 = AddOne(inputs=node1.outputs)  # Add another node in the loop
+
+        for _ in range(10):
+            node1 = AddOne(inputs=node1.outputs)
+            node2 = AddOne(inputs=node2.outputs)
+
+            # Break if either node's output exceeds 5 or both reach 3
+            if (znflow.resolve(node1.outputs) > 5 or
+                znflow.resolve(node2.outputs) > 5 or
+                znflow.resolve(node1.outputs) == 3 and znflow.resolve(node2.outputs) == 3):
+                break
+
+    graph.run()
+
+    # Assert the correct number of nodes in the graph
+    assert len(graph) <= 10  # Maximum number of iterations allowed
+
+    # Assert that at least one node's output exceeds 5 or both reach 3
+    assert (znflow.resolve(node1.outputs) > 5 or
+            znflow.resolve(node2.outputs) > 5 or
+            znflow.resolve(node1.outputs) == 3 and znflow.resolve(node2.outputs) == 3)

--- a/tests/test_dynamic.py
+++ b/tests/test_dynamic.py
@@ -1,0 +1,24 @@
+import znflow
+import dataclasses
+
+
+@dataclasses.dataclass
+class AddOne(znflow.Node):
+    inputs: float
+    outputs: float = None
+
+    def run(self):
+        self.outputs = self.inputs + 1
+
+def test_break_loop():
+    graph = znflow.DiGraph()
+    with graph:
+        node1 = AddOne(inputs=1)
+        for _ in range(10):
+            node1 = AddOne(inputs=node1.outputs)
+            if znflow.resolve(node1.outputs) > 5:
+                break
+
+    graph.run()
+    assert len(graph) == 5
+    assert node1.outputs == 6

--- a/tests/test_dynamic.py
+++ b/tests/test_dynamic.py
@@ -106,7 +106,7 @@ def test_loop_over_results():
         nodes = []
         for idx in range(znflow.resolve(node1.outputs)):
             nodes.append(AddOne(inputs=idx))
-        
+
     graph.run()
     assert len(nodes) == 6
     assert [node.outputs for node in nodes] == [1, 2, 3, 4, 5, 6]

--- a/tests/test_dynamic.py
+++ b/tests/test_dynamic.py
@@ -59,9 +59,12 @@ def test_break_loop_multiple():
     assert len(graph) <= 10  # Maximum number of iterations allowed
 
     # Assert that at least one node's output exceeds 5 or both reach 3
-    assert (znflow.resolve(node1.outputs) > 5 or
-            znflow.resolve(node2.outputs) > 5 or
-            znflow.resolve(node1.outputs) == 3 and znflow.resolve(node2.outputs) == 3)
+    assert (
+        znflow.resolve(node1.outputs) > 5
+        or znflow.resolve(node2.outputs) > 5
+        or znflow.resolve(node1.outputs) == 3
+        and znflow.resolve(node2.outputs) == 3
+    )
 
 
 def test_resolvce_only_run_relevant_nodes():
@@ -75,12 +78,12 @@ def test_resolvce_only_run_relevant_nodes():
             node1 = AddOne(inputs=node1.outputs)
             if znflow.resolve(node1.outputs) > 5:
                 break
-    
+
     # this has to be executed, because of the resolve
-    assert node1.outputs == 6 
-    
+    assert node1.outputs == 6
+
     # this should not be executed, because it is not relevant to the resolve
-    assert node2.outputs is None 
+    assert node2.outputs is None
 
     graph.run()
     assert node2.outputs == 1235

--- a/tests/test_dynamic.py
+++ b/tests/test_dynamic.py
@@ -89,6 +89,7 @@ def test_resolvce_only_run_relevant_nodes():
     assert node2.outputs == 1235
     assert node1.outputs == 6
 
+
 def test_connections_remain():
     graph = znflow.DiGraph()
     with graph:
@@ -96,4 +97,3 @@ def test_connections_remain():
         result = znflow.resolve(node1.outputs)
         assert isinstance(result, int)
         assert isinstance(node1.outputs, znflow.Connection)
-            

--- a/tests/test_dynamic.py
+++ b/tests/test_dynamic.py
@@ -9,8 +9,8 @@ class AddOne(znflow.Node):
     outputs: int = None
 
     def run(self):
-        # if self.outputs is not None:
-        #     raise ValueError("Node has already been run")
+        if self.outputs is not None:
+            raise ValueError("Node has already been run")
         self.outputs = self.inputs + 1
 
 

--- a/tests/test_late_updates.py
+++ b/tests/test_late_updates.py
@@ -1,0 +1,37 @@
+import dataclasses
+import znflow
+from znflow import node
+
+@dataclasses.dataclass
+class AddOne(znflow.Node):
+    inputs: int
+    outputs: int = None
+
+    def run(self):
+        self.outputs = self.inputs + 1
+
+def test_update_after_exit():
+    graph = znflow.DiGraph()
+    with graph:
+        node1 = AddOne(inputs=1)
+
+    node1.inputs = 2
+    graph.run(immutable_nodes=False)
+    assert node1.outputs == 3
+
+    node1.inputs = 3
+    graph.run(immutable_nodes=False)
+    assert node1.outputs == 4
+
+def test_update_after_exit_immutable():
+    graph = znflow.DiGraph()
+    with graph:
+        node1 = AddOne(inputs=1)
+
+    node1.inputs = 2
+    graph.run()
+    assert node1.outputs == 3
+
+    node1.inputs = 3
+    graph.run()
+    assert node1.outputs == 3

--- a/tests/test_late_updates.py
+++ b/tests/test_late_updates.py
@@ -13,16 +13,16 @@ class AddOne(znflow.Node):
 
 
 def test_update_after_exit():
-    graph = znflow.DiGraph()
+    graph = znflow.DiGraph(immutable_nodes=False)
     with graph:
         node1 = AddOne(inputs=1)
 
     node1.inputs = 2
-    graph.run(immutable_nodes=False)
+    graph.run()
     assert node1.outputs == 3
 
     node1.inputs = 3
-    graph.run(immutable_nodes=False)
+    graph.run()
     assert node1.outputs == 4
 
 

--- a/tests/test_late_updates.py
+++ b/tests/test_late_updates.py
@@ -1,6 +1,7 @@
 import dataclasses
+
 import znflow
-from znflow import node
+
 
 @dataclasses.dataclass
 class AddOne(znflow.Node):
@@ -9,6 +10,7 @@ class AddOne(znflow.Node):
 
     def run(self):
         self.outputs = self.inputs + 1
+
 
 def test_update_after_exit():
     graph = znflow.DiGraph()
@@ -22,6 +24,7 @@ def test_update_after_exit():
     node1.inputs = 3
     graph.run(immutable_nodes=False)
     assert node1.outputs == 4
+
 
 def test_update_after_exit_immutable():
     graph = znflow.DiGraph()

--- a/znflow/__init__.py
+++ b/znflow/__init__.py
@@ -19,6 +19,7 @@ from znflow.combine import combine
 from znflow.graph import DiGraph
 from znflow.node import Node, nodify
 from znflow.visualize import draw
+from znflow.dynamic import resolve
 
 __version__ = importlib.metadata.version(__name__)
 
@@ -37,6 +38,7 @@ __all__ = [
     "exceptions",
     "get_graph",
     "empty_graph",
+    "resolve",
 ]
 
 with contextlib.suppress(ImportError):

--- a/znflow/base.py
+++ b/znflow/base.py
@@ -8,6 +8,9 @@ from uuid import UUID
 
 from znflow import exceptions
 
+if typing.TYPE_CHECKING:
+    from znflow.graph import DiGraph
+
 
 @contextlib.contextmanager
 def disable_graph(*args, **kwargs):
@@ -126,7 +129,7 @@ class NodeBaseMixin:
         raise NotImplementedError
 
 
-def get_graph():
+def get_graph() -> DiGraph:
     return NodeBaseMixin._graph_
 
 

--- a/znflow/dynamic.py
+++ b/znflow/dynamic.py
@@ -14,7 +14,7 @@ def resolve(value: t.Union[Connection, t.Any], immutable_nodes: bool = True) -> 
     value : Connection
         The connection to resolve.
     immutable_nodes : bool
-        If True, the nodes are assumed to be immutable and 
+        If True, the nodes are assumed to be immutable and
         will not be rerun. If you change the inputs of a node
         after it has been run, the outputs will not be updated.
 

--- a/znflow/dynamic.py
+++ b/znflow/dynamic.py
@@ -3,7 +3,23 @@ import typing as t
 from znflow.base import Connection, disable_graph, get_graph
 
 
-def resolve(value: Connection | t.Any):
+def resolve(value: t.Union[Connection, t.Any]):
+    """Resolve a Connection to its actual value.
+
+    Allows dynamic resolution of connections to their actual values within a graph context.
+    This will run all Nodes up to this connection.
+    
+    Attributes
+    ----------
+    value : Connection
+        The connection to resolve.
+    
+    Returns
+    -------
+    t.Any
+        The actual value of the connection.
+    
+    """
     # TODO: support nodify as well
     if not isinstance(value, (Connection)):
         return value
@@ -17,6 +33,6 @@ def resolve(value: Connection | t.Any):
         return result
     
     with disable_graph():
-        graph.run()
+        graph.run(nodes=[value.instance])
         result = value.result
     return result

--- a/znflow/dynamic.py
+++ b/znflow/dynamic.py
@@ -3,7 +3,7 @@ import typing as t
 from znflow.base import Connection, disable_graph, get_graph
 
 
-def resolve(value: t.Union[Connection, t.Any], immutable_nodes: bool = True) -> t.Any:
+def resolve(value: t.Union[Connection, t.Any]) -> t.Any:
     """Resolve a Connection to its actual value.
 
     Allows dynamic resolution of connections to their actual values
@@ -13,10 +13,6 @@ def resolve(value: t.Union[Connection, t.Any], immutable_nodes: bool = True) -> 
     ----------
     value : Connection
         The connection to resolve.
-    immutable_nodes : bool
-        If True, the nodes are assumed to be immutable and
-        will not be rerun. If you change the inputs of a node
-        after it has been run, the outputs will not be updated.
 
     Returns
     -------
@@ -36,6 +32,6 @@ def resolve(value: t.Union[Connection, t.Any], immutable_nodes: bool = True) -> 
     graph = get_graph()
 
     with disable_graph():
-        graph.run(nodes=[value.instance], immutable_nodes=immutable_nodes)
+        graph.run(nodes=[value.instance])
         result = value.result
     return result

--- a/znflow/dynamic.py
+++ b/znflow/dynamic.py
@@ -3,7 +3,7 @@ import typing as t
 from znflow.base import Connection, disable_graph, get_graph
 
 
-def resolve(value: t.Union[Connection, t.Any]):
+def resolve(value: t.Union[Connection, t.Any]) -> t.Any:
     """Resolve a Connection to its actual value.
 
     Allows dynamic resolution of connections to their actual values 
@@ -25,12 +25,11 @@ def resolve(value: t.Union[Connection, t.Any]):
         return value
     # get the actual value
     with disable_graph():
-        # if the node has not been run yet, run it
         result = value.result
-    if result is None:
-        graph = get_graph()
-    else:
+    if result is not None:
         return result
+    # we assume, that if the result is None, the node has not been run yet
+    graph = get_graph()
 
     with disable_graph():
         graph.run(nodes=[value.instance])

--- a/znflow/dynamic.py
+++ b/znflow/dynamic.py
@@ -6,13 +6,15 @@ import typing as t
 def resolve(value: Connection| t.Any):
     # TODO: support nodify as well
     if not isinstance(value, (Connection)):
-        raise ValueError(f"Expected a Node, got {value}")
+        return value
     # get the actual value
     with disable_graph():
         # if the node has not been run yet, run it
         result = value.result
     if result is None:
         graph = get_graph()
+    else:
+        return result
     
     with disable_graph():
         graph.run()

--- a/znflow/dynamic.py
+++ b/znflow/dynamic.py
@@ -3,7 +3,7 @@ import typing as t
 from znflow.base import Connection, disable_graph, get_graph
 
 
-def resolve(value: t.Union[Connection, t.Any]) -> t.Any:
+def resolve(value: t.Union[Connection, t.Any], immutable_nodes: bool = True) -> t.Any:
     """Resolve a Connection to its actual value.
 
     Allows dynamic resolution of connections to their actual values
@@ -13,6 +13,10 @@ def resolve(value: t.Union[Connection, t.Any]) -> t.Any:
     ----------
     value : Connection
         The connection to resolve.
+    immutable_nodes : bool
+        If True, the nodes are assumed to be immutable and 
+        will not be rerun. If you change the inputs of a node
+        after it has been run, the outputs will not be updated.
 
     Returns
     -------
@@ -32,6 +36,6 @@ def resolve(value: t.Union[Connection, t.Any]) -> t.Any:
     graph = get_graph()
 
     with disable_graph():
-        graph.run(nodes=[value.instance])
+        graph.run(nodes=[value.instance], immutable_nodes=immutable_nodes)
         result = value.result
     return result

--- a/znflow/dynamic.py
+++ b/znflow/dynamic.py
@@ -8,17 +8,17 @@ def resolve(value: t.Union[Connection, t.Any]):
 
     Allows dynamic resolution of connections to their actual values within a graph context.
     This will run all Nodes up to this connection.
-    
+
     Attributes
     ----------
     value : Connection
         The connection to resolve.
-    
+
     Returns
     -------
     t.Any
         The actual value of the connection.
-    
+
     """
     # TODO: support nodify as well
     if not isinstance(value, (Connection)):

--- a/znflow/dynamic.py
+++ b/znflow/dynamic.py
@@ -6,8 +6,8 @@ from znflow.base import Connection, disable_graph, get_graph
 def resolve(value: t.Union[Connection, t.Any]):
     """Resolve a Connection to its actual value.
 
-    Allows dynamic resolution of connections to their actual values within a graph context.
-    This will run all Nodes up to this connection.
+    Allows dynamic resolution of connections to their actual values 
+    within a graph context. This will run all Nodes up to this connection.
 
     Attributes
     ----------

--- a/znflow/dynamic.py
+++ b/znflow/dynamic.py
@@ -1,0 +1,20 @@
+import dis
+from znflow.node import Node
+from znflow.base import Connection, disable_graph, get_graph
+import typing as t
+
+def resolve(value: Connection| t.Any):
+    # TODO: support nodify as well
+    if not isinstance(value, (Connection)):
+        raise ValueError(f"Expected a Node, got {value}")
+    # get the actual value
+    with disable_graph():
+        # if the node has not been run yet, run it
+        result = value.result
+    if result is None:
+        graph = get_graph()
+    
+    with disable_graph():
+        graph.run()
+        result = value.result
+    return result

--- a/znflow/graph.py
+++ b/znflow/graph.py
@@ -142,29 +142,50 @@ class DiGraph(nx.MultiDiGraph):
             all_pipelines += nx.dfs_postorder_nodes(reverse, stage)
         return list(dict.fromkeys(all_pipelines))  # remove duplicates but keep order
 
-    def run(self, nodes: typing.Optional[typing.List[NodeBaseMixin]] = None):
+    def run(self, nodes: typing.Optional[typing.List[NodeBaseMixin]] = None, immutable_nodes: bool = True):
+        """Run the graph.
+        
+        Attributes
+        ----------
+        nodes : list[Node]
+            The nodes to run. If None, all nodes are run.
+        immutable_nodes : bool
+            If True, the nodes are assumed to be immutable and 
+            will not be rerun. If you change the inputs of a node
+            after it has been run, the outputs will not be updated.
+        """
         if nodes is not None:
             for node_uuid in self.reverse():
+                if immutable_nodes and self.nodes[node_uuid].get("available", False):
+                    continue
                 node = self.nodes[node_uuid]["value"]
                 if node in nodes:
                     predecessors = list(self.predecessors(node.uuid))
                     for predecessor in predecessors:
                         predecessor_node = self.nodes[predecessor]["value"]
-                        print(f"Predecessor: {predecessor_node}")
+                        if immutable_nodes and self.nodes[predecessor].get("available", False):
+                            continue
                         self._update_node_attributes(
                             predecessor_node, handler.UpdateConnectors()
                         )
                         predecessor_node.run()
+                        if immutable_nodes:
+                            self.nodes[predecessor]["available"] = True
                     self._update_node_attributes(node, handler.UpdateConnectors())
-                    print(f"Node: {node}")
                     node.run()
+                    if immutable_nodes:
+                        self.nodes[node_uuid]["available"] = True
         else:
             for node_uuid in self.get_sorted_nodes():
+                if immutable_nodes and self.nodes[node_uuid].get("available", False):
+                    continue
                 node = self.nodes[node_uuid]["value"]
                 if not node._external_:
                     # update connectors
                     self._update_node_attributes(node, handler.UpdateConnectors())
                     node.run()
+                    if immutable_nodes:
+                        self.nodes[node_uuid]["available"] = True
 
     def write_graph(self, *args):
         for node in args:

--- a/znflow/graph.py
+++ b/znflow/graph.py
@@ -142,15 +142,19 @@ class DiGraph(nx.MultiDiGraph):
             all_pipelines += nx.dfs_postorder_nodes(reverse, stage)
         return list(dict.fromkeys(all_pipelines))  # remove duplicates but keep order
 
-    def run(self, nodes: typing.Optional[typing.List[NodeBaseMixin]] = None, immutable_nodes: bool = True):
+    def run(
+        self,
+        nodes: typing.Optional[typing.List[NodeBaseMixin]] = None,
+        immutable_nodes: bool = True,
+    ):
         """Run the graph.
-        
+
         Attributes
         ----------
         nodes : list[Node]
             The nodes to run. If None, all nodes are run.
         immutable_nodes : bool
-            If True, the nodes are assumed to be immutable and 
+            If True, the nodes are assumed to be immutable and
             will not be rerun. If you change the inputs of a node
             after it has been run, the outputs will not be updated.
         """
@@ -163,7 +167,9 @@ class DiGraph(nx.MultiDiGraph):
                     predecessors = list(self.predecessors(node.uuid))
                     for predecessor in predecessors:
                         predecessor_node = self.nodes[predecessor]["value"]
-                        if immutable_nodes and self.nodes[predecessor].get("available", False):
+                        if immutable_nodes and self.nodes[predecessor].get(
+                            "available", False
+                        ):
                             continue
                         self._update_node_attributes(
                             predecessor_node, handler.UpdateConnectors()


### PR DESCRIPTION
Introduce dynamic graph building

```python
graph = znflow.DiGraph()
with graph:
    node1 = AddOne(inputs=1)
    for _ in range(10):
        node1 = AddOne(inputs=node1.outputs)
        if znflow.resolve(node1.outputs) > 5:
            break
```

In the current version, there is no flexibility in choosing the deployment version.