### PR TITLE
sentinel object

### DIFF
--- a/znflow/base.py
+++ b/znflow/base.py
@@ -12,6 +12,12 @@ if typing.TYPE_CHECKING:
     from znflow.graph import DiGraph
 
 
+class _NOT_RESVOLED_TYPE:
+    pass
+
+NOT_RESVOLED = _NOT_RESVOLED_TYPE()
+
+
 @contextlib.contextmanager
 def disable_graph(*args, **kwargs):
     """Temporarily disable set the graph to empty.
@@ -354,7 +360,7 @@ class FunctionFuture(NodeBaseMixin):
     kwargs: typing.Dict
     item: any = None
 
-    result: any = dataclasses.field(default=None, init=False, repr=True)
+    result: any = dataclasses.field(default=NOT_RESVOLED, init=False, repr=True)
 
     _protected_ = NodeBaseMixin._protected_ + ["function", "args", "kwargs"]
 

--- a/znflow/dynamic.py
+++ b/znflow/dynamic.py
@@ -1,6 +1,6 @@
 import typing as t
 
-from znflow.base import Connection, disable_graph, get_graph, FunctionFuture
+from znflow.base import Connection, disable_graph, get_graph, FunctionFuture, NOT_RESVOLED
 
 
 def resolve(value: t.Union[Connection, t.Any]) -> t.Any:
@@ -25,7 +25,7 @@ def resolve(value: t.Union[Connection, t.Any]) -> t.Any:
     # get the actual value
     with disable_graph():
         result = value.result
-    if result is not None:
+    if result is not NOT_RESVOLED:
         return result
     # we assume, that if the result is None, the node has not been run yet
     graph = get_graph()


### PR DESCRIPTION
This is not easily done, because we often use `outs: int|float = None` and here `None` is used to check if the `Node` was executed. There is no inherent information, if a `run` was executed or not.